### PR TITLE
Small patch for EventStreamProxy

### DIFF
--- a/reactive-core/src/main/scala/reactive/EventStream.scala
+++ b/reactive-core/src/main/scala/reactive/EventStream.scala
@@ -534,9 +534,10 @@ trait Batchable[A, B] extends EventSource[SeqDelta[A, B]] {
  * An EventStream that is implemented by delegating everything to another EventStream
  */
 trait EventStreamProxy[T] extends EventStream[T] {
-  def self: EventStream[T]
+  protected[this] def self: EventStream[T]
 
   def debugString = self.debugString
+  def debugName = self.debugName
   def flatMap[U](f: T => EventStream[U]): EventStream[U] = self.flatMap[U](f)
   def foldLeft[U](z: U)(f: (U, T) => U): EventStream[U] = self.foldLeft[U](z)(f)
   def map[U](f: T => U): EventStream[U] = self.map[U](f)
@@ -550,6 +551,7 @@ trait EventStreamProxy[T] extends EventStream[T] {
   def distinct: EventStream[T] = self.distinct
   def nonblocking: EventStream[T] = self.nonblocking
   def zipWithStaleness: EventStream[(T, () => Boolean)] = self.zipWithStaleness
+  def throttle(period: Long): EventStream[T] = self.throttle(period)
   private[reactive] def addListener(f: (T) => Unit): Unit = self.addListener(f)
   private[reactive] def removeListener(f: (T) => Unit): Unit = self.removeListener(f)
 

--- a/reactive-core/src/test/scala/reactive/EventStreamProxyTests.scala
+++ b/reactive-core/src/test/scala/reactive/EventStreamProxyTests.scala
@@ -1,0 +1,16 @@
+package reactive
+
+/**
+ * Not actually a test suite; this file will simply not compile if
+ * EventStreamProxy ever falls out of sync with EventStream again.
+ */
+class EventStreamProxyTests {
+
+  // Asserts:
+  //   * all EventStream members should be implemented by EventStreamProxy
+  //   * self doesn't have to be public
+  def proxy[A] = new EventStreamProxy[A] {
+    protected[this] def self = sys.error("???"): EventStream[A]
+  }
+
+}


### PR DESCRIPTION
I guess you don't really use EventStreamProxy in the rest of reactive—but I do, and assuming you aren't planning on deprecating it entirely, I humbly submit a little bit of love for it.
