### PR TITLE
Add dependency on scala-actors.

### DIFF
--- a/reactive-core/build.sbt
+++ b/reactive-core/build.sbt
@@ -3,3 +3,5 @@ name := "reactive-core"
 description := "An FRP framework"
 
 unmanagedSourceDirectories in Compile <++= (scalaBinaryVersion, baseDirectory) { (sv, bd) => Seq(bd / "src" / "main" / ("scala-"+sv)) }
+
+libraryDependencies += "org.scala-lang" % "scala-actors" % "2.10.2"


### PR DESCRIPTION
This pull request might be naive, but I needed to add a dependency on scala-actors to get reactive-core to build with scala 2.10, since it is no longer part of core scala.  Thanks for taking a look...
