### PR TITLE
Comet transport fix.

### DIFF
--- a/reactive-web-lift/src/main/scala/reactive/web/lift/LiftCometTransportType.scala
+++ b/reactive-web-lift/src/main/scala/reactive/web/lift/LiftCometTransportType.scala
@@ -2,6 +2,9 @@ package reactive
 package web
 package lift
 
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.Duration
 import scala.xml.{ NodeSeq, Null, UnprefixedAttribute }
 import net.liftweb.common._
 import net.liftweb.util.Helpers._
@@ -10,13 +13,16 @@ import net.liftweb.http.js.{ JsCmd, JsCmds }
 
 import reactive.logging.HasLogger
 
+import scala.concurrent._
+import scala.concurrent.ExecutionContext.Implicits.global
+
 object LiftCometTransportType {
   private val _overrideCometHack = new scala.util.DynamicVariable(Option.empty[LiftCometTransportType#PageComet])
   private var initted = false
 
-  private def overrideCometHack[A](comet: LiftCometTransportType#PageComet)(f: =>A): A =
-    if(!initted)
-      sys.error("LiftCometSupport was not initialized! You must call LiftCometSupport.init() in boot in order to use LiftCometTransportType.")
+  private def overrideCometHack[A](comet: LiftCometTransportType#PageComet)(f: => A): A =
+    if (!initted)
+      sys.error("LiftCometTransport was not initialized! You must call LiftCometTransportType.init() in boot in order to use LiftCometTransport.")
     else
       _overrideCometHack.withValue(Some(comet))(f)
 
@@ -25,22 +31,28 @@ object LiftCometTransportType {
    */
   def init(): Unit = {
     LiftRules.cometCreation.append {
-      case CometCreationInfo(t, name, defaultXml, attributes, session) if _overrideCometHack.value.isDefined =>
-      val comet = _overrideCometHack.value.get
-      comet.initCometActor(session, Full(t), name, defaultXml, attributes)
-      comet
+      case CometCreationInfo("reactive.web.ReactionsComet", name, defaultXml, attributes, session) if _overrideCometHack.value.isDefined =>
+        val comet = _overrideCometHack.value.get
+        comet.initCometActor(session, Full("reactive.web.ReactionsComet"), name, defaultXml, attributes)
+        comet
     }
     initted = true
   }
 }
 
 class LiftCometTransportType(page: Page) extends TransportType with HasLogger {
+  // Promise that comet actor will be initialized.
+  val initPromise = Promise[Box[String]]()
+  val initFuture = initPromise.future
+
   class PageComet extends CometActor {
     // Make initCometActor accessible
-    override protected[web] def initCometActor(s: LiftSession, t: Box[String], n: Box[String], x: NodeSeq, a: Map[String, String]) =
+    override protected[web] def initCometActor(s: LiftSession, t: Box[String], n: Box[String], x: NodeSeq, a: Map[String, String]): Unit = {
       super.initCometActor(s, t, n, x, a)
+      initPromise success t
+    }
 
-    override def lifespan = Full(60.seconds)
+    override def lifespan = Full(60 seconds)
 
     def render = <span/>
 
@@ -49,12 +61,13 @@ class LiftCometTransportType(page: Page) extends TransportType with HasLogger {
       case js: JsCmd => partialUpdate(js)
     }
   }
+
   val comet = new PageComet
 
   object cometTransport extends Transport {
     def currentPriority: Int = 0
 
-    queued foreach { renderable => comet ! JsCmds.Run(renderable.render) }
+    queued =>> { renderable => comet ! JsCmds.Run(renderable.render) }
   }
 
   LiftCometTransportType.overrideCometHack(comet) {
@@ -64,10 +77,18 @@ class LiftCometTransportType(page: Page) extends TransportType with HasLogger {
     }
   }
 
-  comet !? (comet.cometRenderTimeout, AskRender) foreach {
-    case AnswerRender(_, _, when, _) =>
-      page.queue(s"""var lift_toWatch = lift_toWatch || {}; lift_toWatch['${comet.uniqueId}'] = $when;""")
+  // Ask comet actor for render after his initialization for avoid NPE
+  val askRender = Future {
+    initFuture onSuccess {
+      case Full("reactive.web.ReactionsComet") =>
+        comet !? (comet.cometRenderTimeout, AskRender) foreach {
+          case AnswerRender(_, _, when, _) =>
+            page.queue(s"var lift_toWatch = lift_toWatch || {}; lift_toWatch['${comet.uniqueId}'] = $when;")
+        }
+    }
   }
+  // Waiting for comet actor answer for render lift_toWatch
+  Await.result(askRender, Duration(5, TimeUnit.SECONDS))
 
   override def render = super.render ++ S.session.map{ session =>
     // TODO ensure that it's not already rendered


### PR DESCRIPTION
NPE were fixed for improve snippet rendering time.

The problem is occurred by ask comet actor for render before it was initialized.
Comet actor installation is

``` scala
    // This is how we install our own comet actors in Lift
    S.withAttrs(new UnprefixedAttribute("type", "reactive.web.ReactionsComet", new UnprefixedAttribute("name", page.id, Null))) {
      net.liftweb.builtin.snippet.Comet.render(NodeSeq.Empty)
    }
```

Comet actor creation is calling from 'lift session'

``` scala
    LiftRules.cometCreation.append {
      case CometCreationInfo("reactive.web.ReactionsComet", name, defaultXml, attributes, session) if _overrideCometHack.value.isDefined =>
        val comet = _overrideCometHack.value.get
        comet.initCometActor(session, Full("reactive.web.ReactionsComet"), name, defaultXml, attributes)
        comet
    }
```

So our lift comet actor can be initialised in 'any time'. And this moment can be after asking comet actor for render.

``` scala
        comet !? (comet.cometRenderTimeout, AskRender) foreach {
          case AnswerRender(_, _, when, _) =>
            page.queue(s"var lift_toWatch = lift_toWatch || {}; lift_toWatch['${comet.uniqueId}'] = $when;")
        }
```

In this case is NPE in CometActor occur.

I think that the simplest solution is using Future, Promise, Await for ask comet for render only after comet initialization.
